### PR TITLE
[codex] quiet upgrade guard output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,12 @@
 # Clawback
 
-Clawback is a preflight, container rehearsal, guarded update, and rollback safety tool for OpenClaw installs.
-It captures the current setup, checks the parts most likely to bite during an upgrade, redacts sensitive values, and writes a report that can be compared after installing a newer OpenClaw version.
+Clawback is an upgrade safety tool for OpenClaw installs. It captures a local baseline, rehearses a target OpenClaw version in a sanitized container, writes redacted reports, and provides guarded update/rollback commands.
 
-The project is designed for personal setups first, but the checks are generic enough to share with other OpenClaw users.
-
-## Why This Exists
-
-Clawback started after a real OpenClaw upgrade path hurt more than it should have. A working install moved from `2026.4.26` toward `2026.4.29`, hit upgrade issues, then even `2026.4.26` stopped being a good recovery point. The setup eventually had to be manually rolled back to `2026.4.23`, where OpenClaw was performant and stable again.
-
-That experience exposed the core problem this project tries to solve: every OpenClaw install can be different. Agents, channels, gateway auth, task history, workspace paths, systemd state, device links, and host resources all matter. A version that looks fine in a generic smoke test can still break a specific personal setup. Clawback gives users a repeatable way to capture their own baseline, rehearse a target version in a container, compare behavior, and keep a rollback path ready before touching the live install.
-
-## Platform Support
-
-Clawback is currently Linux/POSIX-first.
-
-- The Node.js CLI is intended to be portable, but it has only been validated on Linux.
-- The helper scripts use `bash` and POSIX shell behavior.
-- The container rehearsal expects Docker or Podman on a Linux-compatible host.
-- The local baseline checks are most complete for Linux installs that use user-level `systemd` for the OpenClaw gateway.
-
-macOS, Windows, WSL, and non-systemd Linux may work for parts of the CLI, but they are not validated yet. Treat results on those platforms as experimental until platform-specific checks are added.
-
-## What It Checks
-
-- OpenClaw CLI availability and runtime version.
-- Gateway reachability and system service state.
-- Gateway misconfiguration signals.
-- Channel health for configured Telegram, WhatsApp, and other supported channels.
-- Agent definitions, workspace paths, and sessions files.
-- Cron scheduler/list commands when available.
-- Durable task audit/list commands when available.
-- Config validation when available.
-- Update metadata, including installed version versus registry latest.
-- Baseline drift after upgrade, such as missing agents or channels that were configured before.
-- Resource pressure during validation, including load average, available memory, and OpenClaw/Node process RSS.
-
-The tool treats immediate runtime failures as errors. Historical task failures, old lost tasks, bootstrap-pending agents, and dependency marker oddities are warnings because those can exist before an upgrade and should not automatically block every user.
+It is Linux/POSIX-first today. The CLI may work elsewhere, but the helper scripts assume `bash`, and container rehearsal expects Docker or Podman.
 
 ## Install
 
-### Use The Latest Released Tag
-
-For a stable checkout, install from the latest GitHub release tag instead of cloning whatever is on `main`.
-
-Current release tag:
+Use the latest release tag for a stable checkout:
 
 ```sh
 git clone --depth 1 --branch v0.1.0 https://github.com/haishmg/Clawback.git clawback
@@ -53,62 +15,16 @@ npm install --ignore-scripts
 node bin/clawback.js --help
 ```
 
-When a newer release exists, replace `v0.1.0` with the newest tag from:
-
-```text
-https://github.com/haishmg/Clawback/releases/latest
-```
-
-If you want the command available globally from that tagged checkout:
+To make `clawback` available globally from the checkout:
 
 ```sh
 npm link
 clawback --help
 ```
 
-From a checkout:
+Replace `v0.1.0` with the newest tag from `https://github.com/haishmg/Clawback/releases/latest` when a newer release exists.
 
-```sh
-cd /path/to/clawback
-npm install
-npm link
-```
-
-After `npm link`, run it from anywhere:
-
-```sh
-clawback --help
-```
-
-Or run directly from inside the checkout:
-
-```sh
-cd /path/to/clawback
-node bin/clawback.js --help
-```
-
-If you are outside the checkout, use the full path:
-
-```sh
-node /path/to/clawback/bin/clawback.js --help
-```
-
-For example, on this host:
-
-```sh
-node /home/pii/Clawback/bin/clawback.js --help
-```
-
-## Recommended Upgrade Workflow
-
-Use the guard as a staged upgrade gate:
-
-1. Run a local baseline on the current working install.
-2. Run a container-level target check against a sanitized fixture.
-3. If the container check passes, use the guarded updater.
-4. Run post-upgrade validation on the live host after the gateway settles.
-
-The container check is intentionally first because it is non-mutating and catches package/config/gateway compatibility problems before the host is touched. It is not a complete host replica, so it cannot be the only gate.
+## Upgrade Workflow
 
 Run the pre-upgrade suite before changing OpenClaw:
 
@@ -116,210 +32,110 @@ Run the pre-upgrade suite before changing OpenClaw:
 npm run suite:pre
 ```
 
-This exports a sanitized fixture, then runs the local baseline and container rehearsal in parallel. Review both generated files:
+This exports a sanitized fixture, then runs the local baseline and container rehearsal in parallel. The suite prints `[suite]` and `[container]` progress lines for fixture export, local baseline, image build, and isolated rehearsal.
+
+Review both summaries:
 
 ```sh
 less reports/before-upgrade/summary.md
 less reports/container-rehearsal/run/summary.md
 ```
 
-If the container rehearsal fails, do not upgrade. If it passes, use the guarded update command printed by the rehearsal output.
+To rehearse a specific OpenClaw target:
 
-Run the post-upgrade comparison:
+```sh
+OPENCLAW_PACKAGE=openclaw@2026.4.29 npm run suite:pre
+```
+
+If the container rehearsal fails, do not upgrade. If it passes, start with the guarded update dry run printed by the rehearsal output.
+
+Run the post-upgrade comparison after upgrading:
 
 ```sh
 npm run suite:post
 ```
 
-Post-upgrade mode waits up to 120 seconds for the gateway to settle before it starts judging health, channels, and baseline drift. Use `--settle <seconds>` when running the CLI directly if a host needs a longer or shorter restart window.
+Post-upgrade mode waits up to 120 seconds for the gateway to settle, then compares live health, channels, agents, and baseline drift. If it reports errors, fix them before trusting the upgraded install or roll back with the recorded rollback plan.
 
-If the post-upgrade run reports errors, fix those before trusting the upgraded install or roll back with the recorded rollback plan. If it reports warnings, decide whether they match known historical state or represent new risk.
+## Guarded Update
 
-Running `node bin/clawback.js` directly only runs the local guard. It does not start Docker or Podman. Use `npm run suite:pre` when you want the local baseline and latest-version container rehearsal together. Container rehearsal uses `container-rehearsal` mode, which checks the sanitized config/state with latest OpenClaw, starts a foreground gateway inside the container, and treats failed gateway RPC/probe results as hard errors. Host-only features such as systemd service installation and absolute host workspace paths remain warnings.
+Dry-run the host update first:
 
-## Container-Level Checks
+```sh
+npm run upgrade:apply -- --target 2026.4.29 --report reports/container-rehearsal/run/report.json
+```
 
-Container rehearsal is the project’s main non-mutating upgrade check. It builds a clean Linux image, installs the requested OpenClaw package, loads a sanitized copy of your OpenClaw state, starts a foreground gateway, waits for readiness, and then runs the same validation probes used by the local guard.
+Apply only after reviewing the dry run:
 
-Run a plain container rehearsal:
+```sh
+npm run upgrade:apply -- --target 2026.4.29 --report reports/container-rehearsal/run/report.json --accept-low-fidelity --yes
+```
+
+If post-upgrade validation fails, roll back:
+
+```sh
+npm run upgrade:rollback -- --plan reports/updates/<run>/rollback.json --yes
+npm run suite:post
+```
+
+The updater refuses to change the host unless the report matches the requested target and has zero hard errors. Reports marked with `container.fidelity.host_replica` require `--accept-low-fidelity` because a sanitized container is not a full live-host replica.
+
+## Direct Commands
+
+Run only the local guard:
+
+```sh
+node bin/clawback.js --mode baseline
+```
+
+Run only a container rehearsal:
 
 ```sh
 npm run container:export -- ~/.openclaw fixtures/openclaw-sanitized
 OPENCLAW_PACKAGE=openclaw@latest npm run container:rehearse -- fixtures/openclaw-sanitized
 ```
 
-For the most useful version decision, compare the target against a same-harness container baseline from your currently working version:
+Compare a target against a same-harness container baseline:
 
 ```sh
 npm run container:export -- ~/.openclaw fixtures/openclaw-sanitized
 OPENCLAW_BASELINE_PACKAGE=openclaw@2026.4.23 OPENCLAW_PACKAGE=openclaw@2026.4.29 npm run container:compare -- fixtures/openclaw-sanitized
 ```
 
-This first runs the baseline package against the exported fixture and saves it under `reports/container-baselines/`. It then runs the target package with `--baseline` against that control report, so warnings already present in the current version do not become false blockers, but new capability regressions do.
-
-Container-level checks can catch:
-
-- Target package install failures.
-- Config/schema incompatibility with the sanitized state.
-- Gateway startup, readiness, RPC, identity, and scope regressions.
-- Command output changes, including commands that stop returning parseable JSON.
-- Agent/channel metadata drift that is visible in the fixture.
-- CPU, memory, and process RSS pressure during the rehearsal.
-
-Important: the sanitized container is not a full clone of the live host. It does not exercise the user systemd service, live channel auth/device stores, external workspace directories, task history, locks, logs, media, memory, or runtime caches. Treat it as a compatibility smoke test. A real upgrade decision still needs the local baseline and post-upgrade validation.
-
-When a container rehearsal passes, the tool prints the guarded update commands to run next. Start with the dry-run command. If the report is low-fidelity, the guarded updater requires `--accept-low-fidelity` before it will apply the host update.
-
-See [docs/container-rehearsal.md](docs/container-rehearsal.md) for details and limitations.
-
-Container images can consume multiple GB on small hosts after repeated rebuilds. See the Podman/Docker disk usage notes in [docs/container-rehearsal.md](docs/container-rehearsal.md#podman-and-docker-disk-usage).
-
-## Parallel Suite
-
-The pre-upgrade baseline and container rehearsal are independent, so the suite runs them at the same time:
-
-```sh
-npm run suite:pre
-```
-
-The suite prints `[suite]` and `[container]` progress lines when it exports the fixture, starts the local baseline, builds the Docker/Podman image, and runs the isolated latest-version rehearsal.
-
-The post-upgrade comparison intentionally runs later, after you have upgraded OpenClaw:
-
-```sh
-npm run suite:post
-```
-
-Use `OPENCLAW_PACKAGE` to rehearse a specific OpenClaw target:
-
-```sh
-OPENCLAW_PACKAGE=openclaw@2026.4.29 npm run suite:pre
-```
-
-## Guarded Update And Rollback
-
-After a target version has a passing container rehearsal, the guard can moderate the host update. It refuses to update unless the report is for the same target version and has zero hard errors. Reports marked with the `container.fidelity.host_replica` warning also require explicit `--accept-low-fidelity` acknowledgement before the host is changed.
-
-Dry-run the host update first:
-
-```sh
-npm run upgrade:apply -- --target 2026.4.24 --report reports/container-rehearsal/run/report.json
-```
-
-Apply the update only after reviewing the dry-run:
-
-```sh
-npm run upgrade:apply -- --target 2026.4.24 --report reports/container-rehearsal/run/report.json --accept-low-fidelity --yes
-```
-
-The command writes a rollback plan under `reports/updates/`. If post-upgrade validation fails, roll back to the previously installed version:
-
-```sh
-npm run upgrade:rollback -- --plan reports/updates/<run>/rollback.json --yes
-```
-
-Then run:
-
-```sh
-npm run suite:post
-```
-
-## Exit Codes
-
-- `0`: no hard errors.
-- `1`: errors were found, or warnings were found with `--strict-warnings`.
-- `2`: the guard itself failed, for example due to invalid arguments.
+See [docs/container-rehearsal.md](docs/container-rehearsal.md) for container details, limitations, and Docker/Podman disk usage notes.
 
 ## Reports
-
-During a run, the CLI prints progress for each validation probe to stderr. You can see what is being checked, whether a probe is required or optional, retry attempts for JSON probes, and how long each command took. Use `--quiet` to suppress progress output.
-
-After a run, the CLI prints the most important results first: overall pass/fail, check counts, OpenClaw version, gateway/service state, configured agents/channels, top errors or warnings, and a `file://` link to the generated HTML dashboard.
-It also prints an upgrade recommendation: upgrade looks safe, upgrade with caution, do not upgrade yet, or do not trust the upgraded install yet.
 
 Each run writes:
 
 - `report.json`: machine-readable command results and checks with common secrets redacted.
 - `summary.md`: human-readable findings and next steps.
-- `report.html`: interactive visual dashboard with severity filters, search, expandable details, and command timing bars.
+- `report.html`: interactive dashboard with severity filters, search, expandable details, timing bars, and resource cards.
 
-The JSON report intentionally includes command output summaries. Do not publish reports without reviewing them, especially if your local OpenClaw install uses custom channels, private workspaces, or unusual plugin configuration.
+By default, CLI progress shows only important checkpoints: phases plus failed, warning, or retried probes. Use `--debug` to print every validation probe and command result. Use `--quiet` to suppress progress output.
 
-Render an HTML dashboard for an existing JSON report:
+Exit codes:
 
-```sh
-npm run report:html -- reports/before-upgrade/report.json
-```
+- `0`: no hard errors.
+- `1`: errors were found, or warnings were found with `--strict-warnings`.
+- `2`: the guard itself failed, for example due to invalid arguments.
 
-Then open the generated `report.html` in a browser.
+## What It Checks
 
-### Sample Run Output
+Clawback checks OpenClaw CLI availability, runtime/update metadata, gateway reachability, service state, configured channels, agents, workspace/session paths, cron/task commands, config validation, baseline drift, and host resource pressure.
 
-A local baseline run prints the validation phases, command probes, and the most important result immediately:
+Immediate runtime failures are errors. Historical task failures, old lost tasks, bootstrap-pending agents, unavailable optional commands, and container-only host fidelity gaps are warnings unless they represent a new baseline regression.
 
-```text
-[phase] Starting preflight validation
-[run] Detect OpenClaw CLI version (required)
-      openclaw --version
-[ok] version: exit 0, 149ms
-[run] Collect runtime, gateway, agent, task, and update status (required attempt 1/3)
-      openclaw status --json
-[ok] status: exit 0, 5317ms
-[run] Probe live channel and heartbeat health (optional attempt 1/3)
-      openclaw health --json
-[ok] health: exit 0, 3233ms
-[phase] Evaluating command output and upgrade invariants
-[phase] Evaluation complete: pass
+## Limitations
 
-Clawback: PASS
-Checks: 50 total, 44 passed, 6 warnings, 0 errors
-Mode: baseline
-OpenClaw: 2026.4.24 (latest: 2026.4.29)
-Gateway: reachable at ws://127.0.0.1:18789
-Gateway service: running
-Agents: 6
-Configured channels: telegram, whatsapp
-Recommendation: Upgrade only with caution
-
-Most important warnings:
-- status.update_available: Registry latest is 2026.4.29; installed runtime is 2026.4.24
-- tasks.history: Historical failed/lost tasks are present; review before blaming an upgrade
-
-HTML report: file:///home/pii/clawback/reports/before-upgrade/report.html
-Markdown summary: /home/pii/clawback/reports/before-upgrade/summary.md
-JSON report: /home/pii/clawback/reports/before-upgrade/report.json
-```
-
-The matching `summary.md` starts with the same decision data in a shareable format:
-
-```text
-# Clawback Report
-
-- Result: PASS
-- Mode: baseline
-- Checks: 50
-- Errors: 0
-- Warnings: 6
-- Recommendation: Upgrade only with caution
-- Resources: peak load/CPU 0.88, min memory available 68.1%, peak process RSS 262 MiB
-
-## Upgrade Guidance
-
-No hard blockers were found, but warnings remain. Review them before upgrading.
-```
-
-The HTML dashboard shows the same result visually, with severity filters, search, expandable command details, timing bars, resource cards, and direct links back to the generated JSON and Markdown files.
-
-## Current Limitations
-
-- Container rehearsal is not a full live-host replica unless you deliberately mount/copy additional state.
+- Container rehearsal is a compatibility smoke test, not a full live-host clone.
+- It does not exercise live channel auth/device stores, external workspace directories, task history, locks, logs, media, memory, or runtime caches unless you deliberately mount/copy more state.
 - It does not send live test messages to chat channels.
-- It does not run arbitrary repair commands.
-- Optional OpenClaw commands vary by version, so unavailable optional commands become warnings rather than hard failures.
+- Platform coverage outside Linux/POSIX is experimental.
 
 ## Development
 
-Run tests and a CLI smoke check:
+Run tests and smoke checks:
 
 ```sh
 npm test
@@ -334,10 +150,4 @@ Run against a non-default OpenClaw executable:
 node bin/clawback.js --openclaw /path/to/openclaw --mode baseline
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for pull request expectations and [docs/regression.md](docs/regression.md) for the regression strategy.
-
-## Releases
-
-Releases are created from annotated `v*` tags. The release workflow runs CI, packs the npm tarball, creates a GitHub Release, and attaches the package artifact.
-
-See [CHANGELOG.md](CHANGELOG.md) and [docs/releases.md](docs/releases.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md), [docs/regression.md](docs/regression.md), [docs/releases.md](docs/releases.md), and [CHANGELOG.md](CHANGELOG.md).

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,6 +17,7 @@ Options:
   --out <dir>            Report directory (default: ./reports/<timestamp>)
   --baseline <file>      Previous JSON report to compare against
   --json                 Print JSON report to stdout
+  --debug                Print every validation probe and command result
   --no-markdown          Do not write summary.md
   --no-html              Do not write report.html
   --quiet                Suppress progress output
@@ -33,7 +34,7 @@ export async function main(argv) {
 
   const report = await runGuard({
     ...options,
-    onProgress: options.quiet ? undefined : (event) => printProgress(event),
+    onProgress: options.quiet ? undefined : (event) => printProgress(event, { debug: options.debug }),
   });
   const outDir = options.out || defaultReportDir();
   fs.mkdirSync(outDir, { recursive: true });
@@ -69,6 +70,7 @@ export function parseArgs(argv) {
     settleSeconds: null,
     markdown: true,
     html: true,
+    debug: false,
     quiet: false,
     strictWarnings: false,
   };
@@ -86,6 +88,7 @@ export function parseArgs(argv) {
 
     if (arg === "--help" || arg === "-h") options.help = true;
     else if (arg === "--json") options.json = true;
+    else if (arg === "--debug") options.debug = true;
     else if (arg === "--no-markdown") options.markdown = false;
     else if (arg === "--no-html") options.html = false;
     else if (arg === "--quiet") options.quiet = true;
@@ -116,12 +119,13 @@ function defaultReportDir() {
   return path.join(process.cwd(), "reports", stamp);
 }
 
-function printProgress(event) {
+function printProgress(event, options = {}) {
   if (event.type === "phase") {
     console.error(`[phase] ${event.message}`);
     return;
   }
   if (event.type === "command-start") {
+    if (!options.debug) return;
     const commandText = ["openclaw", ...event.command.args].join(" ");
     const retryText = event.maxAttempts > 1 ? ` attempt ${event.attempt}/${event.maxAttempts}` : "";
     const requiredText = event.command.required ? "required" : "optional";
@@ -132,6 +136,7 @@ function printProgress(event) {
   if (event.type === "command-end") {
     const result = event.result;
     const status = result.ok && !result.parseError ? "ok" : event.retrying ? "retry" : result.required ? "error" : "warn";
+    if (!options.debug && status === "ok") return;
     const parseNote = result.parseError ? `, parse: ${result.parseError}` : "";
     const retryNote = event.retrying ? ", retrying" : "";
     console.error(`[${status}] ${event.command.id}: exit ${result.exitCode}, ${result.durationMs}ms${parseNote}${retryNote}`);

--- a/test/checks.test.js
+++ b/test/checks.test.js
@@ -347,6 +347,7 @@ test("argument parser validates timeout", () => {
   assert.equal(parseArgs(["--mode", "container-rehearsal"]).mode, "container-rehearsal");
   assert.equal(parseArgs(["--mode", "post-upgrade", "--settle", "180"]).settleSeconds, 180);
   assert.equal(parseArgs(["--no-html"]).html, false);
+  assert.equal(parseArgs(["--debug"]).debug, true);
   assert.equal(parseArgs(["--quiet"]).quiet, true);
 });
 


### PR DESCRIPTION
## Summary

- Add a --debug flag for exhaustive upgrade guard progress output.
- Keep default progress focused on phases plus failed, warning, or retried probes.
- Consolidate and shorten the README around the main upgrade workflow.

## Validation

- npm run check
